### PR TITLE
Annotations model

### DIFF
--- a/doc/event-schema/annotation-event-schema.md
+++ b/doc/event-schema/annotation-event-schema.md
@@ -1,0 +1,11 @@
+# AnnotationEvent
+
+```yaml
+AnnotationEvent:
+  message: String
+  tags: Vector<AnnotationTag>
+
+AnnotationTag:
+  key: String
+  value: String
+```

--- a/doc/event-schema/annotation-event-schema.md
+++ b/doc/event-schema/annotation-event-schema.md
@@ -2,7 +2,7 @@
 
 ```yaml
 AnnotationEvent:
-  message: String
+  description: String
   tags: Vector<AnnotationTag>
 
 AnnotationTag:


### PR DESCRIPTION
Add the model for annotation events. The annotation event is used as annotations on charts in Grafana or Kibana.