### PR TITLE
Change LZ4 decompressor. fast -> safe. For prevent segfault hercules-gate on incorrect data

### DIFF
--- a/hercules-util/src/main/java/ru/kontur/vostok/hercules/util/compression/Lz4Decompressor.java
+++ b/hercules-util/src/main/java/ru/kontur/vostok/hercules/util/compression/Lz4Decompressor.java
@@ -1,7 +1,7 @@
 package ru.kontur.vostok.hercules.util.compression;
 
 import net.jpountz.lz4.LZ4Factory;
-import net.jpountz.lz4.LZ4FastDecompressor;
+import net.jpountz.lz4.LZ4SafeDecompressor;
 
 import java.nio.ByteBuffer;
 
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer;
  * @author Gregory Koshelev
  */
 public class Lz4Decompressor implements Decompressor {
-    private final LZ4FastDecompressor decompressor = LZ4Factory.fastestInstance().fastDecompressor();
+    private final LZ4SafeDecompressor decompressor = LZ4Factory.fastestInstance().safeDecompressor();
 
     @Override
     public void decompress(ByteBuffer src, ByteBuffer dest) {


### PR DESCRIPTION
In some cases (on incorrect input data) hercules-gate can be crashed on lz4 decode.
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f37938e8030, pid=897699, tid=897775
#
# JRE version: OpenJDK Runtime Environment (11.0.10+9) (build 11.0.10+9-Ubuntu-0ubuntu1.20.04)
# Java VM: OpenJDK 64-Bit Server VM (11.0.10+9-Ubuntu-0ubuntu1.20.04, mixed mode, sharing, tiered, compressed oops, g1 gc, linux-amd64)
# Problematic frame:
# C  [liblz4-java-13752355133479793383.so+0x19030]  LZ4_decompress_fast+0x300
#
# Core dump will be written. Default location: Core dumps may be processed with "/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h" (or dumping to /home/inhavk/temp/hercules-gate-test/core.897699)
#
# An error report file with more information is saved as:
# /home/inhavk/temp/hercules-gate-test/hs_err_pid897699.log
#
# If you would like to submit a bug report, please visit:
#   https://bugs.launchpad.net/ubuntu/+source/openjdk-lts
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```

This commit fixes this problem, but with performance degradation.